### PR TITLE
Fixing nexus publishing for oss-publish framework.

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -28,7 +28,28 @@ jar {
 compileJava {
     options.encoding = 'utf-8'
     options.compilerArgs << '-parameters'
+    options.compilerArgs << '-Xlint'
+    options.compilerArgs << '-Xlint:-processing'
+
+    options.fork = true
+    options.forkOptions.jvmArgs << '-Xmx256m'
+
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
+
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+
+    options.fork = true
+    options.forkOptions.jvmArgs << '-Xmx256m'
+}
+
 
 repositories {
     mavenCentral()
@@ -70,6 +91,9 @@ dependencies {
 }
 
 test {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed", "standardError"

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,10 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
 }
 
-idea {
-    project{
-        vcs = "Git"
-        languageLevel = "11"
-    }
+idea.project {
+    vcs = 'Git'
+    languageLevel = JavaVersion.VERSION_17
+    targetBytecodeVersion = JavaVersion.VERSION_17
 }
 
 task tagRelease {
@@ -25,6 +24,15 @@ task tagRelease {
         }
         catch (RefAlreadyExistsException ignored) {
             logger.warn("Tag v$version already exists.")
+        }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv("SONATYPE_USER")
+            password = System.getenv("SONATYPE_PASSWORD")
         }
     }
 }


### PR DESCRIPTION
## Context

Fixing nexus publishing for oss-publish framework.

Currently it fails, because of:

```
* Exception is:
org.gradle.execution.TaskSelectionException: Task 'initializeSonatypeStagingRepository' not found in root project 'tw-gaffer-jta' and its subprojects.
```

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
