### PR TITLE
Added a plugin capable of downloading missing tool-chains.

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -93,6 +93,7 @@ dependencies {
 test {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
+
     }
     useJUnitPlatform()
     testLogging {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,9 +7,12 @@
  * in the user guide at https://docs.gradle.org/4.6/userguide/multi_project_builds.html
  */
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
 rootProject.name = 'tw-spyql'
 
 include 'tw-spyql-core'
 include 'tw-spyql-simple-logger'
 include 'tw-spyql-starter'
-


### PR DESCRIPTION
## Context

Added a plugin capable of downloading missing tool-chains.

Our oss-publish has only JDK 13/17 preinstalled.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
