### PR TITLE
Fixing Nexus build in oss-publish tool.

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -56,8 +56,6 @@ repositories {
     mavenLocal()
 }
 
-group = "com.transferwise.common"
-
 configurations {
     local {
         canBeResolved(false)

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ task tagRelease {
     }
 }
 
+group = "com.transferwise.common"
+
 nexusPublishing {
     repositories {
         sonatype {


### PR DESCRIPTION
## Context

Fixing Nexus build in oss-publish tool.

Currently it fails with an error indicating the group is not defined in main build.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
