### PR TITLE
[APPENG-587] Add support for Spring Boot 3.1.2

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -1,1 +1,8 @@
 runChecks: true
+actions:
+  branch-protection-settings:
+    branches:
+      - name: master
+        checks:
+          - name: Build and Test
+            type: tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,10 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.0.6
-          - 2.7.11
-          - 2.6.14
+          - 3.1.2
+          - 3.0.9
+          - 2.7.14
+          - 2.6.15
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2023-08-03
+
+### Added
+
+* Support for Spring Boot 3.1
+
+### Bumped
+
+* Build against Spring Boot 3.0.6 --> 3.0.9
+* Build against Spring Boot 2.7.11 --> 2.7.14
+* Build against Spring Boot 2.6.14 --> 2.6.15
+
 ## [1.6.0] - 2023-05-09
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "2.6.14"
+    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "2.6.15"
 
     libraries = [
             // explicit versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.6.0
+version=1.6.1


### PR DESCRIPTION
## Context

Spring Boot 3.1.2 is out now so adding support for that version in this library.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
