### PR TITLE
Create BeanPostProcessor beans in static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2024-04-05
+
+### Changed
+* Use static methods to create BeanPostProcessors.
+
 ## [1.6.2] - 2024-02-22
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.6.2
+version=1.6.3

--- a/tw-spyql-starter/src/main/java/com/transferwise/common/spyql/starter/SpyqlAutoConfiguration.java
+++ b/tw-spyql-starter/src/main/java/com/transferwise/common/spyql/starter/SpyqlAutoConfiguration.java
@@ -9,7 +9,7 @@ public class SpyqlAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public SpyqlDataSourceBeanProcessor spyqlDataSourceBeanProcessor() {
+  public static SpyqlDataSourceBeanProcessor spyqlDataSourceBeanProcessor() {
     return new SpyqlDataSourceBeanProcessor();
   }
 }


### PR DESCRIPTION
## Context

Create BeanPostProcessor beans in static methods to avoid the autoconfiguration classes to be processed in bean post-processing phase and logging a warning.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
